### PR TITLE
Send HTML download emails

### DIFF
--- a/ckanext/query_dois/lib/emails.py
+++ b/ckanext/query_dois/lib/emails.py
@@ -2,13 +2,8 @@ import socket
 
 from ckan.lib import mailer
 
-# TODO: put both of these in the config/interface so that they can be overridden
-default_download_body = '''
-A DOI has been created for this data: https://doi.org/{} (this may take a few hours to be active).
-Please ensure you reference this DOI when citing this data.
-For more information, follow the DOI link.
-'''.strip()
-
+# TODO: put this in the config/interface so that it can be overridden
+# TODO: add html version of the body
 default_save_body = '''
 Hello,
 

--- a/ckanext/query_dois/logic/utils.py
+++ b/ckanext/query_dois/logic/utils.py
@@ -10,7 +10,6 @@ from functools import partial
 
 from ckan import model
 from ckan.plugins import toolkit
-from eevee.utils import to_timestamp
 from sqlalchemy import false
 
 
@@ -93,3 +92,15 @@ def extract_resource_ids_and_versions(req_version=None, req_resource_ids=None,
         if rounded_version is not None:
             resource_ids_and_versions[resource_id] = rounded_version
     return resource_ids_and_versions
+
+
+def to_timestamp(moment: datetime) -> int:
+    '''
+    Converts the given moment to a UNIX epoch in milliseconds.
+
+    :param moment: a datetime object
+    :return: integer UNIX epoch in milliseconds
+    '''
+    ts = moment.timestamp()
+    # multiply by 1000 to get the time in milliseconds and use int to remove any decimal places
+    return int(ts * 1000)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,79 @@
+from ckanext.query_dois.plugin import QueryDOIsPlugin
+from unittest.mock import MagicMock, patch
+
+
+class TestIntegrationWithIVersionedDatastoreDownloads:
+
+    @patch('ckanext.query_dois.plugin.extract_resource_ids_and_versions')
+    @patch('ckanext.query_dois.plugin.record_stat')
+    def test_download_email_context_is_modified(self, extract_mock, record_stat_mock):
+        plugin = QueryDOIsPlugin()
+
+        request = MagicMock()
+        context = {}
+        doi = MagicMock(doi='some/doi')
+
+        mint_mock = MagicMock(return_value=(MagicMock(), doi))
+
+        with patch('ckanext.query_dois.plugin.mint_multisearch_doi', mint_mock):
+            ret_context = plugin.download_modify_email_template_context(request, context)
+
+        assert ret_context is context
+        assert context['doi'] == doi.doi
+
+    @patch('ckanext.query_dois.plugin.record_stat')
+    def test_download_email_context_is_always_returned_when_extract_errors(self, record_stat_mock):
+        plugin = QueryDOIsPlugin()
+
+        request = MagicMock()
+        context = {}
+
+        extract_mock = MagicMock(side_effect=Exception)
+        mint_mock = MagicMock()
+
+        with patch('ckanext.query_dois.plugin.extract_resource_ids_and_versions', extract_mock):
+            with patch('ckanext.query_dois.plugin.mint_multisearch_doi', mint_mock):
+                ret_context = plugin.download_modify_email_template_context(request, context)
+
+        assert ret_context is context
+        assert 'doi' not in context
+
+    @patch('ckanext.query_dois.plugin.record_stat')
+    def test_download_email_context_is_always_returned_when_mint_errors(self, record_stat_mock):
+        plugin = QueryDOIsPlugin()
+
+        request = MagicMock()
+        context = {}
+
+        extract_mock = MagicMock()
+        mint_mock = MagicMock(side_effect=Exception)
+
+        with patch('ckanext.query_dois.plugin.extract_resource_ids_and_versions', extract_mock):
+            with patch('ckanext.query_dois.plugin.mint_multisearch_doi', mint_mock):
+                ret_context = plugin.download_modify_email_template_context(request, context)
+
+        assert ret_context is context
+        assert 'doi' not in context
+
+    @patch('ckanext.query_dois.plugin.extract_resource_ids_and_versions')
+    def test_download_email_context_contains_doi_if_we_get_one_even_if_error(self, extract_mock):
+        '''
+        If the DOI gets generated we should stick it in the context as soon as possible. This means that
+        even if less important calls fail (like the record_stat call) we'll get a doi back in the
+        context. This test checks that functionality.
+        '''
+        plugin = QueryDOIsPlugin()
+
+        request = MagicMock()
+        context = {}
+        doi = MagicMock(doi='some/doi')
+
+        mint_mock = MagicMock(return_value=(MagicMock(), doi))
+        record_stat_mock = MagicMock(side_effect=Exception)
+
+        with patch('ckanext.query_dois.plugin.record_stat', record_stat_mock):
+            with patch('ckanext.query_dois.plugin.mint_multisearch_doi', mint_mock):
+                ret_context = plugin.download_modify_email_template_context(request, context)
+
+        assert ret_context is context
+        assert context['doi'] == doi.doi

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,8 +8,6 @@ from ckanext.query_dois.lib.utils import get_resource_and_package
 @pytest.mark.usefixtures('clean_db')
 @pytest.mark.filterwarnings('ignore::sqlalchemy.exc.SADeprecationWarning')
 def test_get_resource_and_package():
-    # TODO: this is a dumb test but we need at least one test to have the tests not just constantly
-    #       fail, so here we are
     package = factories.Dataset()
     resource = factories.Resource(package_id=package['id'])
 


### PR DESCRIPTION
This requires https://github.com/NaturalHistoryMuseum/ckanext-versioned-datastore/pull/42 and https://github.com/NaturalHistoryMuseum/ckanext-nhm/pull/491.

This PR implements the new templating functionality in the IVersionedDatastoreDownloads interface to provide the download DOI to the templating context. It also removes the NHM specific default email string which now resides in the NHM plugin (see the related PR).