### PR TITLE
Remove ckanpackager

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ This extension creates (mints) digital object identifiers (DOIs) for queries on 
 
 **Must be used in conjunction with v4+ of the [ckanext-versioned-datastore](https://github.com/NaturalHistoryMuseum/ckanext-versioned-datastore).**
 
-_Optionally:_ [ckanext-ckanpackager](https://github.com/NaturalHistoryMuseum/ckanext-ckanpackager) can be used to get DOIs for downloads (`query-dois` automatically hooks into the `ckanext-ckanpackager` interface if it finds the plugin is active in the running CKAN environment).
-
 You will need an account with a DataCite DOI service provider to use this extension.
 
 <!--overview-end-->

--- a/ckanext/query_dois/lib/doi.py
+++ b/ckanext/query_dois/lib/doi.py
@@ -272,6 +272,8 @@ def mint_doi(resource_ids, datastore_query):
         timestamp,
         record_count,
         requested_version=datastore_query.requested_version,
+        query_version='v0',
+        resource_counts={resource_id: record_count},
     )
     return True, query_doi
 

--- a/ckanext/query_dois/migration/query_dois/README
+++ b/ckanext/query_dois/migration/query_dois/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/ckanext/query_dois/migration/query_dois/alembic.ini
+++ b/ckanext/query_dois/migration/query_dois/alembic.ini
@@ -1,0 +1,74 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = %(here)s
+
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# timezone to use when rendering the date
+# within the migration file as well as the filename.
+# string value is passed to dateutil.tz.gettz()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the
+# "slug" field
+#truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; this defaults
+# to /base/src/ckan/ckanext-query-dois/ckanext/query_dois/migration/query_dois/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path
+# version_locations = %(here)s/bar %(here)s/bat /base/src/ckan/ckanext-query-dois/ckanext/query_dois/migration/query_dois/versions
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+sqlalchemy.url = driver://user:pass@localhost/dbname
+
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/ckanext/query_dois/migration/query_dois/env.py
+++ b/ckanext/query_dois/migration/query_dois/env.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import with_statement
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from logging.config import fileConfig
+
+import os
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = None
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+name = os.path.basename(os.path.dirname(__file__))
+
+
+def run_migrations_offline():
+    """
+    Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+    """
+
+    url = config.get_main_option(u"sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        version_table=u'{}_alembic_version'.format(name),
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """
+    Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine and associate a connection with the
+    context.
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix=u'sqlalchemy.',
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            version_table=u'{}_alembic_version'.format(name),
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/ckanext/query_dois/migration/query_dois/script.py.mako
+++ b/ckanext/query_dois/migration/query_dois/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/ckanext/query_dois/migration/query_dois/versions/a74242a670e0_set_old_query_version.py
+++ b/ckanext/query_dois/migration/query_dois/versions/a74242a670e0_set_old_query_version.py
@@ -1,0 +1,46 @@
+"""
+Set old query version.
+
+Revision ID: a74242a670e0
+Revises:
+Create Date: 2023-06-09 12:20:05.632095
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import orm
+from sqlalchemy.ext.declarative import declarative_base
+
+# revision identifiers, used by Alembic.
+revision = 'a74242a670e0'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+Base = declarative_base()
+
+
+class QueryDOI(Base):
+    __tablename__ = 'query_doi'
+    id = sa.Column(sa.UnicodeText, primary_key=True)
+    query_version = sa.Column(sa.UnicodeText, nullable=True)
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = orm.Session(bind=bind)
+
+    for query_doi in session.query(QueryDOI).filter(QueryDOI.query_version.is_(None)):
+        query_doi.query_version = 'v0'
+
+    session.commit()
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = orm.Session(bind=bind)
+
+    for query_doi in session.query(QueryDOI).filter(QueryDOI.query_version == 'v0'):
+        query_doi.query_version = None
+
+    session.commit()

--- a/ckanext/query_dois/plugin.py
+++ b/ckanext/query_dois/plugin.py
@@ -17,6 +17,7 @@ from .lib.stats import DOWNLOAD_ACTION, record_stat
 from .logic import auth, action
 from .logic.utils import extract_resource_ids_and_versions
 
+
 log = logging.getLogger(__name__)
 
 
@@ -28,10 +29,13 @@ class QueryDOIsPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IAuthFunctions)
     plugins.implements(plugins.IClick)
     # if the versioned datastore downloader is available, we have a hook for it
-    with suppress(ImportError):
+    try:
         from ckanext.versioned_datastore.interfaces import IVersionedDatastoreDownloads
 
         plugins.implements(IVersionedDatastoreDownloads, inherit=True)
+        versioned_datastore_available = True
+    except ImportError:
+        versioned_datastore_available = False
 
     # IBlueprint
     def get_blueprint(self):
@@ -134,4 +138,5 @@ class QueryDOIsPlugin(plugins.SingletonPlugin):
             'create_multisearch_citation_text': helpers.create_multisearch_citation_text,
             'pretty_print_query': helpers.pretty_print_query,
             'get_doi_count': helpers.get_doi_count,
+            'versioned_datastore_available': self.versioned_datastore_available,
         }

--- a/ckanext/query_dois/routes/_helpers.py
+++ b/ckanext/query_dois/routes/_helpers.py
@@ -161,27 +161,6 @@ def generate_rerun_urls(resource, package, query, rounded_version):
     }
 
 
-def get_download_url(package, resource, query, rounded_version):
-    """
-    Returns the URL for the CKANPackager's download endpoint, or None if the
-    CKANPackager is not in use.
-
-    :param package: the package dict
-    :param resource: the resource dict
-    :param query: the query dict
-    :param rounded_version: the version rounded down to the nearest available on the resource
-    :return: the URL for packaging the resource up with the CKANPackager or None if the
-             CKANPackager is not installed
-    """
-    try:
-        from ckanext.ckanpackager.lib.utils import url_for_package_resource
-
-        url = url_for_package_resource(package['id'], resource['id'], use_request=False)
-        return url + '&' + encode_params(query, version=rounded_version)
-    except ImportError:
-        return None
-
-
 def get_stats(query_doi):
     '''
     Retrieve some simple stats about the query DOI - this includes the total downloads and the
@@ -242,9 +221,6 @@ def render_datastore_search_doi_page(query_doi):
         'version': rounded_version,
         'reruns': generate_rerun_urls(
             resource, package, query_doi.query, rounded_version
-        ),
-        'download_url': get_download_url(
-            package, resource, query_doi.query, rounded_version
         ),
         'downloads': downloads,
         'last_download_timestamp': last_download_timestamp,

--- a/ckanext/query_dois/routes/query_doi.py
+++ b/ckanext/query_dois/routes/query_doi.py
@@ -29,7 +29,7 @@ def landing_page(data_centre, identifier):
     if query_doi is None:
         raise toolkit.abort(404, toolkit._('DOI not recognised'))
 
-    if query_doi.query_version is not None:
+    if query_doi.query_version is not None and query_doi.query_version != 'v0':
         return _helpers.render_multisearch_doi_page(query_doi)
     else:
         return _helpers.render_datastore_search_doi_page(query_doi)

--- a/ckanext/query_dois/theme/templates/query_dois/multisearch_landing_page.html
+++ b/ckanext/query_dois/theme/templates/query_dois/multisearch_landing_page.html
@@ -122,53 +122,14 @@
     </div>
 
     <div class="module, module-narrow module-shallow">
-        {% asset 'ckanext-query-dois/multisearch' %}
         <h2 class="module-heading">
             <i class="far fa-arrow-alt-circle-down fa-lg inline-icon-left"></i>{{ _('Download') }}
         </h2>
         <div class="module-content">
-            <p>
-              {% trans %}
-                  Request to download the data associated with this DOI as it looked when the DOI
-                  was minted.
-              {% endtrans %}
-            </p>
-            <div class="form-group">
-                <div class="form-row">
-                    <label for="download-format">File format</label>
-                    <select id="download-format"
-                            class="full-width">
-                        <option value="csv">CSV/TSV</option>
-                        <option value="dwc">Darwin Core</option>
-                        <option value="xlsx">Excel (XLSX)</option>
-                        <option value="json">JSON</option>
-                    </select>
-                </div>
-                <div class="form-row flex-container flex-wrap flex-between">
-                    <div class="no-pad-h">
-                        <label for="download-sep">One file per resource</label>
-                        <input
-                            id="download-sep"
-                            type="checkbox" checked>
-                    </div>
-                    <div class="no-pad-h">
-                        <label for="download-empty">Skip empty columns</label>
-                        <input id="download-empty"
-                               type="checkbox" checked>
-                    </div>
-                </div>
-                <small>View this query on the <a target="_blank" href="/search/{{ original_slug }}">search page</a> for more advanced download options, including email notifications.</small>
-            </div>
-
-            {% block privacy_warning %}{% endblock %}
-            <div class="text-left">
-                <a id="download-button" href="#" class="btn btn-primary text-right"
-                   data-query='{{ query_doi.query|tojson }}'
-                   data-query-version='{{ query_doi.query_version }}'
-                   data-resources-and-versions='{{ query_doi.resources_and_versions|tojson }}'>
-                    <i class="fas fa-download"></i> Request Download
-                </a>
-            </div>
+            {% snippet 'versioned_datastore/snippets/download_button.html',
+            slug_or_doi=query_doi.doi,
+            icon_class="fas fa-download",
+            label=_('Download') %}
         </div>
     </div>
 {% endblock %}

--- a/ckanext/query_dois/theme/templates/query_dois/multisearch_landing_page.html
+++ b/ckanext/query_dois/theme/templates/query_dois/multisearch_landing_page.html
@@ -121,6 +121,7 @@
         </div>
     </div>
 
+    {% if h.versioned_datastore_available %}
     <div class="module, module-narrow module-shallow">
         <h2 class="module-heading">
             <i class="far fa-arrow-alt-circle-down fa-lg inline-icon-left"></i>{{ _('Download') }}
@@ -132,4 +133,5 @@
             label=_('Download') %}
         </div>
     </div>
+    {% endif %}
 {% endblock %}

--- a/ckanext/query_dois/theme/templates/query_dois/single_landing_page.html
+++ b/ckanext/query_dois/theme/templates/query_dois/single_landing_page.html
@@ -150,9 +150,11 @@
     <h2 class="module-heading">
         <i class="far fa-arrow-alt-circle-down fa-lg inline-icon-left"></i>{{ _('Download') }}
     </h2>
-    {% asset 'ckanext-ckanpackager/main-css' %}
-    {% asset 'ckanext-ckanpackager/main-js' %}
-    <a data-module="ckanpackager-download-link" data-module-resource-id="{{ resource['id'] }}"
-       class="packager-link btn btn-primary" href="{{ download_url }}">{{ _('Download') }}</a>
+    <div class="module-content">
+        {% snippet 'versioned_datastore/snippets/download_button.html',
+            slug_or_doi=query_doi.doi,
+            icon_class="fas fa-download",
+            label=_('Download') %}
+    </div>
 </div>
 {% endblock %}

--- a/ckanext/query_dois/theme/templates/query_dois/single_landing_page.html
+++ b/ckanext/query_dois/theme/templates/query_dois/single_landing_page.html
@@ -146,6 +146,7 @@
     </div>
 </div>
 
+{% if h.versioned_datastore_available %}
 <div class="module, module-narrow module-shallow">
     <h2 class="module-heading">
         <i class="far fa-arrow-alt-circle-down fa-lg inline-icon-left"></i>{{ _('Download') }}
@@ -157,4 +158,5 @@
             label=_('Download') %}
     </div>
 </div>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
[ckanpackager](https://github.com/NaturalHistoryMuseum/ckanpackager) and [ckanext-ckanpackager](https://github.com/NaturalHistoryMuseum/ckanext-ckanpackager) are being deprecated.

This uses new functionality from NaturalHistoryMuseum/ckanext-versioned-datastore#104 to replace them.