### PR TITLE
Handle missing resources

### DIFF
--- a/ckanext/query_dois/theme/assets/less/query_dois.less
+++ b/ckanext/query_dois/theme/assets/less/query_dois.less
@@ -43,3 +43,20 @@
     font-weight: bold;
   }
 }
+
+.qd_warning_banner {
+  width: 100%;
+  padding: 10px;
+  text-align: center;
+
+  & > p:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.qd_block {
+  border-top: 1px solid #eee;
+  border-bottom: 1px solid #eee;
+  padding: 10px 0;
+  margin-bottom: 40px;
+}

--- a/ckanext/query_dois/theme/assets/less/query_dois.less
+++ b/ckanext/query_dois/theme/assets/less/query_dois.less
@@ -48,6 +48,7 @@
   width: 100%;
   padding: 10px;
   text-align: center;
+  margin-bottom: 20px;
 
   & > p:last-child {
     margin-bottom: 0;
@@ -59,4 +60,8 @@
   border-bottom: 1px solid #eee;
   padding: 10px 0;
   margin-bottom: 40px;
+
+  & > p:last-child {
+    margin-bottom: 0;
+  }
 }

--- a/ckanext/query_dois/theme/assets/less/visual_query.less
+++ b/ckanext/query_dois/theme/assets/less/visual_query.less
@@ -32,6 +32,8 @@
 }
 
 .visual_query {
+  padding: 10px;
+
   &:after {
     content: '.';
     visibility: hidden;
@@ -40,7 +42,7 @@
     clear: both;
   }
 
-  pre {
-    height: 200px;
+  & > pre {
+    padding: 0;
   }
 }

--- a/ckanext/query_dois/theme/templates/query_dois/multisearch_landing_page.html
+++ b/ckanext/query_dois/theme/templates/query_dois/multisearch_landing_page.html
@@ -20,6 +20,16 @@
         <div class="module-content">
             <h1 class="page-heading">{{ _('DOI') }}: {{ query_doi.doi }}</h1>
 
+            {% block doi_warnings %}
+            {% if warnings|length > 0 %}
+            <div class="alert-warning qd_warning_banner">
+                {% for warning in warnings %}
+                <p>{{ warning }}</p>
+                {% endfor %}
+            </div>
+            {% endif %}
+            {% endblock %}
+
           {% block visual_query %}
             {% snippet "query_dois/snippets/visual_datastore_multisearch.html", query=query_doi.query %}
               <br/>
@@ -27,58 +37,65 @@
 
           {% block citation %}
               <h3>{{ _('Cite this as') }}</h3>
-              <hr>
-              <div>
+              <div class="qd_block">
                   <p>
                     {{ h.create_multisearch_citation_text(query_doi, html=True) | safe }}
                   </p>
               </div>
-              <br/>
           {% endblock %}
 
           {% block details %}
               <h3>{{ _('Details') }}</h3>
-              <hr>
-              <div class="qd_details">
+              <div class="qd_block qd_details">
                   <div>
-                      <b>{{ _('Resource count:') }}</b> {{ resource_count }}
+                      <b>{{ _('Resource count:') }}</b> {{ details['resource_count'] }}
                   </div>
                   <div>
-                      <b>{{ _('Dataset count:') }}</b> {{ package_count }}
+                      <b>{{ _('Dataset count:') }}</b> {{ details['package_count'] }}
                   </div>
-                {#            <div>#}
-                {#                <b>{{ _('License:') }}</b> {% snippet "snippets/license.html", pkg_dict=package, text_only=True %}#}
-                {#            </div>#}
+                  <div>
+                      <b>{{ _('Total records:') }}</b> {{ details['record_count'] }}
+                  </div>
                   <div>
                       <b>{{ _('Retrieved:') }}</b> {{ query_doi.timestamp }}
                   </div>
+                  {% if has_changed %}
                   <div>
-                      <b>{{ _('Total records:') }}</b> {{ query_doi.count }}
+                      <b>{{ _('Resource count at save time:') }}</b> {{ saved_details['resource_count'] }}
                   </div>
+                  <div>
+                      <b>{{ _('Total records at save time:') }}</b> {{ saved_details['record_count'] }}
+                  </div>
+                  <div>
+                      <b>{{ _('Missing resources:') }}</b> {{ saved_details['missing_resources'] }}
+                  </div>
+                  <div>
+                      <b>{{ _('Missing records:') }}</b> {{ saved_details['missing_records'] }}
+                  </div>
+                  {% endif %}
               </div>
           {% endblock %}
 
           {% block stats %}
               <h3>{{ _('Statistics') }}</h3>
-              <hr>
-              <div class="qd_stats">
+              <div class=" qd_block qd_stats">
                   <div>
-                      <b>{{ _('Total downloads:') }}</b> {{ downloads }}
+                      <b>{{ _('Total downloads:') }}</b> {{ usage_stats['downloads'] }}
                   </div>
                   <div>
-                      <b>{{ _('Total saves:') }}</b> {{ saves }}
+                      <b>{{ _('Total saves:') }}</b> {{ usage_stats['saves'] }}
                   </div>
                   <div>
-                      <b>{{ _('Last downloaded:') }}</b> {{ last_download_timestamp }}
+                      <b>{{ _('Last downloaded:') }}</b> {{ usage_stats['last_download_timestamp'] or _('Never') }}
                   </div>
               </div>
           {% endblock %}
           {% block resource_breakdown %}
+            {% if not is_inaccessible %}
               <h3>{{ _('Resource breakdown') }}</h3>
-              <hr>
-              <div>
+              <div class="qd_block">
                   <table class="qd_breakdown">
-                    {% for resource_id, count in sorted_resource_counts %}
+                    {% for resource_id, count in details['sorted_resource_counts'] %}
                       {% set resource_info = resources[resource_id] %}
                       {% set package_info = packages[resource_info['package_id']] %}
                       {% set resource_url = h.url_for('resource.read', id=package_info['name'], resource_id=resource_id) %}
@@ -91,6 +108,7 @@
                     {% endfor %}
                   </table>
               </div>
+            {% endif %}
           {% endblock %}
         </div>
     </article>
@@ -98,6 +116,20 @@
 
 
 {% block secondary_content %}
+{% if is_inaccessible %}
+    <div class="module, module-narrow module-shallow">
+        <h2 class="module-heading">
+            <i class="fas fa-times fa-lg inline-icon-left"></i>{{ _('Data missing') }}
+        </h2>
+        <div class="module-content">
+            <div class="qd_help_text">
+              {% trans %}
+                  All data associated with this DOI have been deleted, moved, or are no longer available.
+              {% endtrans %}
+            </div>
+        </div>
+    </div>
+{% else %}
     <div class="module module-narrow module-shallow">
         <h2 class="module-heading">
             <i class="fas fa-eye fa-lg inline-icon-left"></i>{{ _('View data') }}
@@ -134,4 +166,5 @@
         </div>
     </div>
     {% endif %}
+{% endif %}
 {% endblock %}

--- a/ckanext/query_dois/theme/templates/query_dois/single_landing_page.html
+++ b/ckanext/query_dois/theme/templates/query_dois/single_landing_page.html
@@ -37,21 +37,18 @@
         {% block citation %}
         {% if not is_inaccessible %}
         <h3>{{ _('Cite this as') }}</h3>
-        <hr>
-        <div>
+        <div class="qd_block">
             <p>
                 {{ h.create_citation_text(query_doi.doi, query_doi.timestamp, resource['name'],
                                           package['title'], package_doi, html=True) | safe }}
             </p>
         </div>
-        <br />
         {% endif %}
         {% endblock %}
 
         {% block details %}
         <h3>{{ _('Details') }}</h3>
-        <hr>
-        <div class="qd_details">
+        <div class="qd_block qd_details">
             {% if not is_inaccessible %}
             <div>
                 {% set resource_url = h.url_for('resource.read', id=package['name'], resource_id=resource['id']) %}
@@ -76,8 +73,7 @@
 
         {% block stats %}
         <h3>{{ _('Statistics') }}</h3>
-        <hr>
-        <div class="qd_stats">
+        <div class="qd_block qd_stats">
               <div>
                   <b>{{ _('Total downloads:') }}</b> {{ usage_stats['downloads'] }}
               </div>

--- a/ckanext/query_dois/theme/templates/query_dois/single_landing_page.html
+++ b/ckanext/query_dois/theme/templates/query_dois/single_landing_page.html
@@ -19,12 +19,23 @@
     <div class="module-content">
         <h1 class="page-heading">{{ _('DOI') }}: {{ doi }}</h1>
 
+        {% block doi_warnings %}
+            {% if warnings|length > 0 %}
+            <div class="alert-warning qd_warning_banner">
+                {% for warning in warnings %}
+                <p>{{ warning }}</p>
+                {% endfor %}
+            </div>
+            {% endif %}
+        {% endblock %}
+
         {% block visual_query %}
         {% snippet "query_dois/snippets/visual_datastore_search.html", search=query_doi.query %}
         <br />
         {% endblock %}
 
         {% block citation %}
+        {% if not is_inaccessible %}
         <h3>{{ _('Cite this as') }}</h3>
         <hr>
         <div>
@@ -34,12 +45,14 @@
             </p>
         </div>
         <br />
+        {% endif %}
         {% endblock %}
 
         {% block details %}
         <h3>{{ _('Details') }}</h3>
         <hr>
         <div class="qd_details">
+            {% if not is_inaccessible %}
             <div>
                 {% set resource_url = h.url_for('resource.read', id=package['name'], resource_id=resource['id']) %}
                 {% set package_url = h.url_for('dataset.read', id=package['name']) %}
@@ -51,6 +64,7 @@
             <div>
                 <b>{{ _('License:') }}</b> {% snippet "snippets/license.html", pkg_dict=package, text_only=True %}
             </div>
+            {% endif %}
             <div>
                 <b>{{ _('Retrieved:') }}</b> {{ query_doi.timestamp }}
             </div>
@@ -64,13 +78,13 @@
         <h3>{{ _('Statistics') }}</h3>
         <hr>
         <div class="qd_stats">
-            <div>
-                <b>{{ _('Total downloads:') }}</b> {{ downloads }}
-            </div>
-            <div>
-                <b>{{ _('Last downloaded:') }}</b> {{ last_download_timestamp }}
-            </div>
-        </div>
+              <div>
+                  <b>{{ _('Total downloads:') }}</b> {{ usage_stats['downloads'] }}
+              </div>
+              <div>
+                  <b>{{ _('Last downloaded:') }}</b> {{ usage_stats['last_download_timestamp'] or _('Never') }}
+              </div>
+          </div>
         {% endblock %}
     </div>
 </article>
@@ -78,6 +92,20 @@
 
 
 {% block secondary_content %}
+{% if is_inaccessible %}
+    <div class="module, module-narrow module-shallow">
+        <h2 class="module-heading">
+            <i class="fas fa-times fa-lg inline-icon-left"></i>{{ _('Data missing') }}
+        </h2>
+        <div class="module-content">
+            <div class="qd_help_text">
+              {% trans %}
+                  All data associated with this DOI have been deleted, moved, or are no longer available.
+              {% endtrans %}
+            </div>
+        </div>
+    </div>
+{% else %}
 <div class="module module-narrow module-shallow">
     <h2 class="module-heading">
         <i class="fas fa-eye fa-lg inline-icon-left"></i>{{ _('View data') }}
@@ -158,5 +186,6 @@
             label=_('Download') %}
     </div>
 </div>
+{% endif %}
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
Filters out missing resources, catches errors, and displays warnings on landing pages.

Multisearch with all resources missing:
![image](https://github.com/user-attachments/assets/ff5af695-6351-4ae3-83ab-7a62dcbdda4a)

Multisearch with some resources missing:
![image](https://github.com/user-attachments/assets/538e1753-3471-4e35-9240-1ed538dedb43)

Single search with missing resource:
![image](https://github.com/user-attachments/assets/f521dc86-e42d-48bd-a5a9-7291edc73468)

Closes: #57 