### PR TITLE
Non-datastore resources

### DIFF
--- a/ckanext/query_dois/routes/_helpers.py
+++ b/ckanext/query_dois/routes/_helpers.py
@@ -9,6 +9,8 @@ import itertools
 import json
 import operator
 from collections import OrderedDict
+from dataclasses import asdict, dataclass
+from typing import Optional
 from urllib.parse import urlencode
 
 from ckan import model
@@ -24,6 +26,23 @@ column_param_mapping = (
     ('domain', QueryDOIStat.domain),
     ('action', QueryDOIStat.action),
 )
+
+
+@dataclass
+class InaccessibleResource:
+    id: Optional[str] = None
+    name: Optional[str] = None
+    package_id: Optional[str] = None
+    package_name: Optional[str] = None
+    package_title: Optional[str] = None
+    record_count: int = 0
+
+    @property
+    def is_unknown(self):
+        return self.name is None
+
+    def as_dict(self):
+        return asdict(self)
 
 
 def get_query_doi(doi):
@@ -281,21 +300,43 @@ def get_package_and_resource_info(resource_ids):
         try:
             resource = raction({}, dict(id=resource_id))
         except (toolkit.ObjectNotFound, toolkit.NotAuthorized):
-            inaccessible_resources.append(resource_id)
+            inaccessible_resources.append(InaccessibleResource(id=resource_id))
             continue
+
         package_id = resource['package_id']
+        if package_id not in packages:
+            # we don't want to save this *yet* in case all the resources are
+            # inaccessible, but we want the package details
+            pkg_dict = paction({}, dict(id=package_id))
+            package = {
+                'title': pkg_dict['title'],
+                'name': pkg_dict['name'],
+                'resource_ids': [],
+            }
+        else:
+            package = packages.get(package_id)
+
+        # for query DOIs, non-datastore counts as inaccessible, but we can still get
+        # the name and package details
+        if not resource.get('datastore_active', False):
+            inaccessible_resources.append(
+                InaccessibleResource(
+                    id=resource_id,
+                    name=resource['name'],
+                    package_id=package_id,
+                    package_name=package['name'],
+                    package_title=package['title'],
+                )
+            )
+            continue
+
+        # now we can save everything
         resources[resource_id] = {
             'name': resource['name'],
             'package_id': package_id,
         }
-        if package_id not in packages:
-            package = paction({}, dict(id=package_id))
-            packages[package_id] = {
-                'title': package['title'],
-                'name': package['name'],
-                'resource_ids': [],
-            }
-        packages[package_id]['resource_ids'].append(resource_id)
+        package['resource_ids'].append(resource_id)
+        packages[package_id] = package
 
     return packages, resources, inaccessible_resources
 
@@ -381,12 +422,12 @@ def render_multisearch_doi_page(query_doi: QueryDOI):
         warnings = [
             toolkit._(
                 'All resources associated with this search have been deleted, moved, '
-                'or are no longer available.'
+                'or are no longer available in their previous format.'
             )
         ]
     else:
         current_slug = create_current_slug(
-            query_doi, ignore_resources=inaccessible_resources
+            query_doi, ignore_resources=[r.id for r in inaccessible_resources]
         )
         if inaccessible_count > 0:
             warnings.append(
@@ -396,6 +437,29 @@ def render_multisearch_doi_page(query_doi: QueryDOI):
                 )
                 + str(inaccessible_count)
             )
+
+    # inaccessible resources
+    unknown = {'resource_count': 0, 'record_count': 0}
+    known = []
+    for res in inaccessible_resources:
+        if res.is_unknown:
+            unknown['resource_count'] += 1
+            unknown['record_count'] += query_doi.resource_counts[res.id]
+        else:
+            res.record_count = query_doi.resource_counts[res.id]
+            known.append(res.as_dict())
+    inaccessible_resource_details = known
+    if unknown['resource_count'] > 0:
+        inaccessible_resource_details.append(
+            InaccessibleResource(
+                id=None,
+                name=' '.join(
+                    [toolkit._('Unknown resources'), f'({unknown["resource_count"]})']
+                ),
+                package_title=toolkit._('Unknown package'),
+                record_count=unknown['record_count'],
+            ).as_dict()
+        )
 
     context = {
         'query_doi': query_doi,
@@ -409,5 +473,6 @@ def render_multisearch_doi_page(query_doi: QueryDOI):
         'has_changed': inaccessible_count > 0,
         'is_inaccessible': len(resources) == 0,
         'warnings': warnings,
+        'inaccessible_resources': inaccessible_resource_details,
     }
     return toolkit.render('query_dois/multisearch_landing_page.html', context)

--- a/ckanext/query_dois/routes/_helpers.py
+++ b/ckanext/query_dois/routes/_helpers.py
@@ -134,7 +134,7 @@ def encode_params(params, version=None, extras=None, for_api=False):
     return urlencode(query_string)
 
 
-def generate_rerun_urls(resource, package, query, rounded_version):
+def generate_rerun_urls(resource, package, query, rounded_version=None):
     """
     Generate a dict containing all the "rerun" URLs needed to allow the user to revisit the data
     either through the website or through the API. The dict returned will look like following:
@@ -161,22 +161,26 @@ def generate_rerun_urls(resource, package, query, rounded_version):
     )
     api_url = '/api/action/datastore_search'
     api_extras = {'resource_id': resource['id']}
-    return {
+    url_dict = {
         'page': {
-            'original': page_url + '?' + encode_params(query, version=rounded_version),
             'current': page_url + '?' + encode_params(query),
-        },
-        'api': {
+        }
+    }
+    if rounded_version is not None:
+        url_dict['page']['original'] = (
+            page_url + '?' + encode_params(query, version=rounded_version)
+        )
+        url_dict['api'] = {
+            'current': api_url
+            + '?'
+            + encode_params(query, extras=api_extras, for_api=True),
             'original': api_url
             + '?'
             + encode_params(
                 query, version=rounded_version, extras=api_extras, for_api=True
             ),
-            'current': api_url
-            + '?'
-            + encode_params(query, extras=api_extras, for_api=True),
-        },
-    }
+        }
+    return url_dict
 
 
 def get_stats(query_doi):
@@ -227,9 +231,11 @@ def render_datastore_search_doi_page(query_doi):
     try:
         resource, package = get_resource_and_package(resource_id)
         is_inaccessible = False
+        in_datastore = resource.get('datastore_active', False)
     except (toolkit.ObjectNotFound, toolkit.NotAuthorized):
         resource = None
         package = None
+        in_datastore = False
         is_inaccessible = True
 
     # we ignore the saves count as it will always be 0 for a datastore_search DOI
@@ -245,7 +251,15 @@ def render_datastore_search_doi_page(query_doi):
         warnings = [
             toolkit._(
                 'All resources associated with this search have been deleted, moved, '
-                'or are no longer available.'
+                'or are no longer available in their previous format.'
+            )
+        ]
+    elif not in_datastore:
+        warnings = [
+            toolkit._(
+                'All records associated with this search have been removed from the '
+                'search index. The data may still exist, but they are no longer '
+                'versioned and cannot be filtered.'
             )
         ]
 
@@ -257,6 +271,7 @@ def render_datastore_search_doi_page(query_doi):
         'version': rounded_version,
         'usage_stats': usage_stats,
         'is_inaccessible': is_inaccessible,
+        'in_datastore': in_datastore,
         'warnings': warnings,
         # these are defaults for if the resource is inaccessible
         'package_doi': None,
@@ -275,7 +290,10 @@ def render_datastore_search_doi_page(query_doi):
                 ),
                 'authors': get_authors([package]),
                 'reruns': generate_rerun_urls(
-                    resource, package, query_doi.query, rounded_version
+                    resource,
+                    package,
+                    query_doi.query,
+                    rounded_version if in_datastore else None,
                 ),
             }
         )

--- a/ckanext/query_dois/theme/templates/query_dois/multisearch_landing_page.html
+++ b/ckanext/query_dois/theme/templates/query_dois/multisearch_landing_page.html
@@ -109,6 +109,29 @@
                   </table>
               </div>
             {% endif %}
+            {% if has_changed %}
+            <h3>{{ _('Missing data') }}</h3>
+              <div class="qd_block">
+                  <table class="qd_breakdown">
+                    {% for resource in inaccessible_resources %}
+                      {% if not resource['id'] %}
+                        <tr>
+                            <td>{{ resource['package_title'] }} / {{ resource['name'] }}</td>
+                            <td><b>{{ resource['record_count'] }} {{ _('records') }}</b></td>
+                        </tr>
+                      {% else %}
+                        {% set resource_url = h.url_for('resource.read', id=resource['package_name'], resource_id=resource['id']) %}
+                        {% set package_url = h.url_for('dataset.read', id=resource['package_name']) %}
+                        <tr>
+                            <td><a href="{{ package_url }}">{{ resource['package_title'] }}</a> / <a
+                                    href="{{ resource_url }}">{{ resource['name'] }}</a></td>
+                            <td><b>{{ resource['record_count'] }} {{ _('records') }}</b></td>
+                        </tr>
+                      {% endif %}
+                    {% endfor %}
+                  </table>
+              </div>
+            {% endif %}
           {% endblock %}
         </div>
     </article>

--- a/ckanext/query_dois/theme/templates/query_dois/single_landing_page.html
+++ b/ckanext/query_dois/theme/templates/query_dois/single_landing_page.html
@@ -35,7 +35,7 @@
         {% endblock %}
 
         {% block citation %}
-        {% if not is_inaccessible %}
+        {% if package %}
         <h3>{{ _('Cite this as') }}</h3>
         <div class="qd_block">
             <p>
@@ -49,7 +49,7 @@
         {% block details %}
         <h3>{{ _('Details') }}</h3>
         <div class="qd_block qd_details">
-            {% if not is_inaccessible %}
+            {% if package %}
             <div>
                 {% set resource_url = h.url_for('resource.read', id=package['name'], resource_id=resource['id']) %}
                 {% set package_url = h.url_for('dataset.read', id=package['name']) %}
@@ -96,7 +96,7 @@
         <div class="module-content">
             <div class="qd_help_text">
               {% trans %}
-                  All data associated with this DOI have been deleted, moved, or are no longer available.
+                  All data associated with this DOI have been deleted, moved, or are no longer available in their previous format.
               {% endtrans %}
             </div>
         </div>
@@ -113,6 +113,7 @@
             </span>
         </i>
     </h2>
+    {% if reruns.page.original %}
     <div class="module-content">
         <a href="{{ reruns.page.original }}">{{ _('Original') }}</a>
         <i class="fas fa-info-circle fa-xs inline-icon-right qd_tooltip">
@@ -123,6 +124,7 @@
             </span>
         </i>
     </div>
+    {% endif %}
     <div class="module-content">
         <a href="{{ reruns.page.current }}">{{ _('Current') }}</a>
         <i class="fas fa-info-circle fa-xs inline-icon-right qd_tooltip">
@@ -136,6 +138,7 @@
     </div>
 </div>
 
+{% if reruns.api %}
 <div class="module module-narrow module-shallow">
     <h2 class="module-heading">
         <i class="fas fa-flask fa-lg inline-icon-left"></i>{{ _('View with API') }}
@@ -169,8 +172,9 @@
         </i>
     </div>
 </div>
+{% endif %}
 
-{% if h.versioned_datastore_available %}
+{% if h.versioned_datastore_available and is_datastore %}
 <div class="module, module-narrow module-shallow">
     <h2 class="module-heading">
         <i class="far fa-arrow-alt-circle-down fa-lg inline-icon-left"></i>{{ _('Download') }}


### PR DESCRIPTION
This fixes the landing pages for DOIs that query resources that were previously in the datastore but have since been removed and exist only as "raw" files.

This should be a very small minority of cases, but is worth covering just in case.
